### PR TITLE
pip: Ignore dependencies installed via easy_install

### DIFF
--- a/shared/pip-dependencies.sh
+++ b/shared/pip-dependencies.sh
@@ -47,5 +47,6 @@ fi
 
 if [ -f "$ARGV_BASE_DIRECTORY/requirements.txt" ]; then
   echo "Installing Python requirements"
-  pip install --quiet --requirement "$ARGV_BASE_DIRECTORY/requirements.txt"
+  pip install --ignore-installed --quiet --requirement "$ARGV_BASE_DIRECTORY/requirements.txt"
 fi
+


### PR DESCRIPTION
Change-type: minor
Signed-off-by: Jack Brown <jack@resin.io>